### PR TITLE
Fix setFitToContent error in old Joplin.

### DIFF
--- a/api/JoplinViewsDialogs.d.ts
+++ b/api/JoplinViewsDialogs.d.ts
@@ -59,4 +59,6 @@ export default class JoplinViewsDialogs {
      * Opens the dialog
      */
     open(handle: ViewHandle): Promise<DialogResult>;
+
+    setFitToContent(handle: ViewHandle, status: boolean) : Promise<boolean>;
 }

--- a/src/DiffWindow.ts
+++ b/src/DiffWindow.ts
@@ -50,7 +50,15 @@ export class DiffWindow {
                 title: 'Cancel',
             },
         ]);
-        await (this.joplinDialogs as any)?.setFitToContent(this.handle, false);
+
+        try {
+            await this.joplinDialogs.setFitToContent(this.handle, false);
+        } catch {
+            // If an exception occurs, that means setFitToContent failed, and we must add the CSS to support old versions.
+            // The below CSS files basically overrides the changes needed to make the CSS work without setFitToContent.
+            console.log('Concflict Resolution: Error setting fitToContent, injecting old styling instead.');
+            await this.joplinDialogs.addScript(this.handle, './ui/DiffWindow/index-old.css');
+        }
     }
 
     /**

--- a/src/DiffWindow.ts
+++ b/src/DiffWindow.ts
@@ -56,7 +56,7 @@ export class DiffWindow {
         } catch {
             // If an exception occurs, that means setFitToContent failed, and we must add the CSS to support old versions.
             // The below CSS files basically overrides the changes needed to make the CSS work without setFitToContent.
-            console.log('Concflict Resolution: Error setting fitToContent, injecting old styling instead.');
+            console.log('Conflict Resolution: Error setting fitToContent, overiding with old styling instead.');
             await this.joplinDialogs.addScript(this.handle, './ui/DiffWindow/index-old.css');
         }
     }

--- a/src/DiffWindow.ts
+++ b/src/DiffWindow.ts
@@ -50,7 +50,7 @@ export class DiffWindow {
                 title: 'Cancel',
             },
         ]);
-        await (this.joplinDialogs as any).setFitToContent(this.handle, false);
+        await (this.joplinDialogs as any)?.setFitToContent(this.handle, false);
     }
 
     /**

--- a/src/ui/DiffWindow/index-old.css
+++ b/src/ui/DiffWindow/index-old.css
@@ -1,0 +1,8 @@
+#joplin-plugin-content {
+    height: 800px;
+    width: 1000px;
+}
+
+#conflictRes-Editor {
+    height: 600px;
+}


### PR DESCRIPTION
I've made a sort of failsafe where it simply reverts the CSS changes back to fixed px values in case setFitToContent doesn't exist. That way the plugin still works with old Joplin versions.

I could have just dropped support for older versions and waited a new Joplin release, but didn't wanna do that.